### PR TITLE
Implement validation/execution contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6945,6 +6945,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-state",
  "tempfile",
+ "tendermint 0.33.0",
  "tendermint-proto 0.32.2",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.44.1"
-source = "git+https://github.com/cosmos/ibc-rs?rev=b00da04#b00da0402f384a0d0b9fd8216b555bbb1b0c4cc7"
+source = "git+https://github.com/cosmos/ibc-rs?rev=9fd3deb#9fd3deb97931d23a0c90d1027fdd4bdaa0707e20"
 dependencies = [
  "borsh",
  "bytes",
@@ -2945,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.3.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=b00da04#b00da0402f384a0d0b9fd8216b555bbb1b0c4cc7"
+source = "git+https://github.com/cosmos/ibc-rs?rev=9fd3deb#9fd3deb97931d23a0c90d1027fdd4bdaa0707e20"
 dependencies = [
  "darling",
  "proc-macro2 1.0.66",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.44.1"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7c49ec1#7c49ec12ab17749772b389d1fc0d14e454bfd7fb"
+source = "git+https://github.com/cosmos/ibc-rs?rev=b00da04#b00da0402f384a0d0b9fd8216b555bbb1b0c4cc7"
 dependencies = [
  "borsh",
  "bytes",
@@ -2945,7 +2945,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.3.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7c49ec1#7c49ec12ab17749772b389d1fc0d14e454bfd7fb"
+source = "git+https://github.com/cosmos/ibc-rs?rev=b00da04#b00da0402f384a0d0b9fd8216b555bbb1b0c4cc7"
 dependencies = [
  "darling",
  "proc-macro2 1.0.66",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ jsonrpsee = {version = "0.18.2", features = ["jsonrpsee-types"] }
 schemars = { version = "0.8.12", features = ["derive"] }
 tempfile = "3.5"
 tokio = { version = "1", features = ["full"] }
-ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "b00da04", features = ["borsh", "schema", "serde"]}
+ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "9fd3deb", features = ["borsh", "schema", "serde"]}
 ibc-proto = { version = "0.34.1", default-features = false, features = ["borsh"] }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ jsonrpsee = {version = "0.18.2", features = ["jsonrpsee-types"] }
 schemars = { version = "0.8.12", features = ["derive"] }
 tempfile = "3.5"
 tokio = { version = "1", features = ["full"] }
-ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "7c49ec1", features = ["borsh", "schema", "serde"]}
+ibc = { git = "https://github.com/cosmos/ibc-rs", rev = "b00da04", features = ["borsh", "schema", "serde"]}
 ibc-proto = { version = "0.34.1", default-features = false, features = ["borsh"] }
 
 

--- a/module-system/module-implementations/sov-ibc/Cargo.toml
+++ b/module-system/module-implementations/sov-ibc/Cargo.toml
@@ -28,6 +28,7 @@ borsh = { workspace = true, features = ["rc"] }
 ibc = { workspace = true }
 ibc-proto = { workspace = true }
 prost = { version = "0.11", default-features = false }
+tendermint = { version = "0.33", default-features = false }
 tendermint-proto = {version = "0.32", default-features = false}
 derive_more = { version = "0.99", default-features = false, features = ["from", "try_into"] }
 

--- a/module-system/module-implementations/sov-ibc/src/call.rs
+++ b/module-system/module-implementations/sov-ibc/src/call.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 
 use crate::context::IbcExecutionContext;
 use crate::router::IbcRouter;
-use crate::IbcModule;
+use crate::Ibc;
 
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq)]
 pub struct RawMsgCreateClient {
@@ -43,7 +43,7 @@ pub enum CallMessage<C: sov_modules_api::Context> {
 #[derive(Debug, Error)]
 enum SetValueError {}
 
-impl<C: sov_modules_api::Context> IbcModule<C> {
+impl<C: sov_modules_api::Context> Ibc<C> {
     pub(crate) fn process_core_message(
         &self,
         msg: MsgEnvelope,

--- a/module-system/module-implementations/sov-ibc/src/context.rs
+++ b/module-system/module-implementations/sov-ibc/src/context.rs
@@ -570,7 +570,7 @@ where
     }
 
     /// TODO: To implement this method there should be a way for IBC module to
-    /// to insert logs into the transaction receipts upon execution
+    /// insert logs into the transaction receipts upon execution
     fn log_message(&mut self, message: String) -> Result<(), ContextError> {
         Ok(())
     }

--- a/module-system/module-implementations/sov-ibc/src/context.rs
+++ b/module-system/module-implementations/sov-ibc/src/context.rs
@@ -332,18 +332,22 @@ where
         self
     }
 
-    fn increase_client_counter(&mut self) {
+    fn increase_client_counter(&mut self) -> Result<(), ContextError> {
         let next_client_counter = self
             .ibc
             .client_counter
             .get(*self.working_set.borrow_mut())
-            .unwrap_or_default()
+            .ok_or(ClientError::Other {
+                description: "Client counter not found".to_string(),
+            })?
             .checked_add(1)
-            .expect("Client counter overflow");
+            .ok_or(ClientError::CounterOverflow)?;
 
         self.ibc
             .client_counter
             .set(&next_client_counter, *self.working_set.borrow_mut());
+
+        Ok(())
     }
 
     fn store_update_time(
@@ -409,18 +413,22 @@ where
         Ok(())
     }
 
-    fn increase_connection_counter(&mut self) {
+    fn increase_connection_counter(&mut self) -> Result<(), ContextError> {
         let next_connection_counter = self
             .ibc
             .connection_counter
             .get(*self.working_set.borrow_mut())
-            .unwrap_or_default()
+            .ok_or(ConnectionError::Other {
+                description: "Connection counter not found".to_string(),
+            })?
             .checked_add(1)
-            .expect("Connection counter overflow");
+            .ok_or(ConnectionError::CounterOverflow)?;
 
         self.ibc
             .connection_counter
             .set(&next_connection_counter, *self.working_set.borrow_mut());
+
+        Ok(())
     }
 
     fn store_packet_commitment(
@@ -521,18 +529,22 @@ where
         Ok(())
     }
 
-    fn increase_channel_counter(&mut self) {
+    fn increase_channel_counter(&mut self) -> Result<(), ContextError> {
         let next_channel_counter = self
             .ibc
             .channel_counter
             .get(*self.working_set.borrow_mut())
-            .unwrap_or_default()
+            .ok_or(ChannelError::Other {
+                description: "Channel counter not found".to_string(),
+            })?
             .checked_add(1)
-            .expect("Channel counter overflow");
+            .ok_or(ChannelError::CounterOverflow)?;
 
         self.ibc
             .channel_counter
             .set(&next_channel_counter, *self.working_set.borrow_mut());
+
+        Ok(())
     }
 
     fn emit_ibc_event(&mut self, event: IbcEvent) {

--- a/module-system/module-implementations/sov-ibc/src/context.rs
+++ b/module-system/module-implementations/sov-ibc/src/context.rs
@@ -7,8 +7,10 @@ use ibc::clients::ics07_tendermint::client_state::ClientState as TmClientState;
 use ibc::core::events::IbcEvent;
 use ibc::core::ics02_client::error::ClientError;
 use ibc::core::ics03_connection::connection::ConnectionEnd;
+use ibc::core::ics03_connection::error::ConnectionError;
 use ibc::core::ics04_channel::channel::ChannelEnd;
 use ibc::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
+use ibc::core::ics04_channel::error::{ChannelError, PacketError};
 use ibc::core::ics04_channel::packet::{Receipt, Sequence};
 use ibc::core::ics23_commitment::commitment::CommitmentPrefix;
 use ibc::core::ics24_host::identifier::{ClientId, ConnectionId};
@@ -43,7 +45,7 @@ where
 
     fn client_state(&self, client_id: &ClientId) -> Result<Self::AnyClientState, ContextError> {
         self.ibc
-            .client_state_store
+            .client_state_map
             .get(client_id, *self.working_set.borrow_mut())
             .ok_or(
                 ClientError::ClientStateNotFound {
@@ -67,7 +69,7 @@ where
         client_cons_state_path: &ClientConsensusStatePath,
     ) -> Result<Self::AnyConsensusState, ContextError> {
         self.ibc
-            .consensus_state_store
+            .consensus_state_map
             .get(client_cons_state_path, *self.working_set.borrow_mut())
             .ok_or(
                 ClientError::ConsensusStateNotFound {
@@ -87,7 +89,18 @@ where
         client_id: &ClientId,
         height: &Height,
     ) -> Result<Timestamp, ContextError> {
-        todo!()
+        self.ibc
+            .client_update_times_map
+            .get(
+                &(client_id.clone(), *height),
+                *self.working_set.borrow_mut(),
+            )
+            .ok_or(
+                ClientError::Other {
+                    description: "Client update time not found".to_string(),
+                }
+                .into(),
+            )
     }
 
     fn client_update_height(
@@ -95,7 +108,18 @@ where
         client_id: &ClientId,
         height: &Height,
     ) -> Result<Height, ContextError> {
-        todo!()
+        self.ibc
+            .client_update_heights_map
+            .get(
+                &(client_id.clone(), *height),
+                *self.working_set.borrow_mut(),
+            )
+            .ok_or(
+                ClientError::Other {
+                    description: "Client update time not found".to_string(),
+                }
+                .into(),
+            )
     }
 
     fn host_height(&self) -> Result<Height, ContextError> {
@@ -116,11 +140,30 @@ where
     }
 
     fn client_counter(&self) -> Result<u64, ContextError> {
-        todo!()
+        self.ibc
+            .client_counter
+            .get(*self.working_set.borrow_mut())
+            .ok_or(
+                ClientError::Other {
+                    description: "Client counter not found".to_string(),
+                }
+                .into(),
+            )
     }
 
     fn connection_end(&self, conn_id: &ConnectionId) -> Result<ConnectionEnd, ContextError> {
-        todo!()
+        self.ibc
+            .connection_end_map
+            .get(
+                &ConnectionPath::new(conn_id),
+                *self.working_set.borrow_mut(),
+            )
+            .ok_or(
+                ConnectionError::ConnectionNotFound {
+                    connection_id: conn_id.clone(),
+                }
+                .into(),
+            )
     }
 
     fn validate_self_client(
@@ -134,55 +177,131 @@ where
     }
 
     fn commitment_prefix(&self) -> CommitmentPrefix {
-        todo!()
+        CommitmentPrefix::try_from("ibc".to_string().into_bytes()).expect("infallible")
     }
 
     fn connection_counter(&self) -> Result<u64, ContextError> {
-        todo!()
+        self.ibc
+            .connection_counter
+            .get(*self.working_set.borrow_mut())
+            .ok_or(
+                ConnectionError::Other {
+                    description: "Connection counter not found".to_string(),
+                }
+                .into(),
+            )
     }
 
     fn channel_end(&self, channel_end_path: &ChannelEndPath) -> Result<ChannelEnd, ContextError> {
-        todo!()
+        self.ibc
+            .channel_end_map
+            .get(channel_end_path, *self.working_set.borrow_mut())
+            .ok_or(
+                ChannelError::ChannelNotFound {
+                    port_id: channel_end_path.0.clone(),
+                    channel_id: channel_end_path.1.clone(),
+                }
+                .into(),
+            )
     }
 
     fn get_next_sequence_send(
         &self,
         seq_send_path: &SeqSendPath,
     ) -> Result<Sequence, ContextError> {
-        todo!()
+        self.ibc
+            .send_sequence_map
+            .get(seq_send_path, *self.working_set.borrow_mut())
+            .ok_or(
+                PacketError::MissingNextSendSeq {
+                    port_id: seq_send_path.0.clone(),
+                    channel_id: seq_send_path.1.clone(),
+                }
+                .into(),
+            )
     }
 
     fn get_next_sequence_recv(
         &self,
         seq_recv_path: &SeqRecvPath,
     ) -> Result<Sequence, ContextError> {
-        todo!()
+        self.ibc
+            .recv_sequence_map
+            .get(seq_recv_path, *self.working_set.borrow_mut())
+            .ok_or(
+                PacketError::MissingNextRecvSeq {
+                    port_id: seq_recv_path.0.clone(),
+                    channel_id: seq_recv_path.1.clone(),
+                }
+                .into(),
+            )
     }
 
     fn get_next_sequence_ack(&self, seq_ack_path: &SeqAckPath) -> Result<Sequence, ContextError> {
-        todo!()
+        self.ibc
+            .ack_sequence_map
+            .get(seq_ack_path, *self.working_set.borrow_mut())
+            .ok_or(
+                PacketError::MissingNextAckSeq {
+                    port_id: seq_ack_path.0.clone(),
+                    channel_id: seq_ack_path.1.clone(),
+                }
+                .into(),
+            )
     }
 
     fn get_packet_commitment(
         &self,
         commitment_path: &CommitmentPath,
     ) -> Result<PacketCommitment, ContextError> {
-        todo!()
+        self.ibc
+            .packet_commitment_map
+            .get(commitment_path, *self.working_set.borrow_mut())
+            .ok_or(
+                PacketError::PacketCommitmentNotFound {
+                    sequence: commitment_path.sequence,
+                }
+                .into(),
+            )
     }
 
     fn get_packet_receipt(&self, receipt_path: &ReceiptPath) -> Result<Receipt, ContextError> {
-        todo!()
+        self.ibc
+            .packet_receipt_map
+            .get(receipt_path, *self.working_set.borrow_mut())
+            .ok_or(
+                PacketError::PacketReceiptNotFound {
+                    sequence: receipt_path.sequence,
+                }
+                .into(),
+            )
     }
 
     fn get_packet_acknowledgement(
         &self,
         ack_path: &AckPath,
     ) -> Result<AcknowledgementCommitment, ContextError> {
-        todo!()
+        self.ibc
+            .packet_ack_map
+            .get(ack_path, *self.working_set.borrow_mut())
+            .ok_or(
+                PacketError::PacketAcknowledgementNotFound {
+                    sequence: ack_path.sequence,
+                }
+                .into(),
+            )
     }
 
     fn channel_counter(&self) -> Result<u64, ContextError> {
-        todo!()
+        self.ibc
+            .channel_counter
+            .get(*self.working_set.borrow_mut())
+            .ok_or(
+                ChannelError::Other {
+                    description: "Channel counter not found".to_string(),
+                }
+                .into(),
+            )
     }
 
     fn max_expected_time_per_block(&self) -> core::time::Duration {
@@ -203,7 +322,17 @@ where
     }
 
     fn increase_client_counter(&mut self) {
-        todo!()
+        let next_client_counter = self
+            .ibc
+            .client_counter
+            .get(*self.working_set.borrow_mut())
+            .unwrap_or_default()
+            .checked_add(1)
+            .expect("Client counter overflow");
+
+        self.ibc
+            .client_counter
+            .set(&next_client_counter, *self.working_set.borrow_mut());
     }
 
     fn store_update_time(
@@ -212,7 +341,12 @@ where
         height: Height,
         timestamp: Timestamp,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc.client_update_times_map.set(
+            &(client_id, height),
+            &timestamp,
+            *self.working_set.borrow_mut(),
+        );
+        Ok(())
     }
 
     fn store_update_height(
@@ -221,7 +355,12 @@ where
         height: Height,
         host_height: Height,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc.client_update_heights_map.set(
+            &(client_id, height),
+            &host_height,
+            *self.working_set.borrow_mut(),
+        );
+        Ok(())
     }
 
     fn store_connection(
@@ -229,7 +368,12 @@ where
         connection_path: &ConnectionPath,
         connection_end: ConnectionEnd,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc.connection_end_map.set(
+            connection_path,
+            &connection_end,
+            *self.working_set.borrow_mut(),
+        );
+        Ok(())
     }
 
     fn store_connection_to_client(
@@ -237,11 +381,35 @@ where
         client_connection_path: &ClientConnectionPath,
         conn_id: ConnectionId,
     ) -> Result<(), ContextError> {
-        todo!()
+        let mut connection_ids = self
+            .ibc
+            .connection_ids_map
+            .get(client_connection_path, *self.working_set.borrow_mut())
+            .unwrap_or_default();
+
+        connection_ids.push(conn_id);
+
+        self.ibc.connection_ids_map.set(
+            client_connection_path,
+            &connection_ids,
+            *self.working_set.borrow_mut(),
+        );
+
+        Ok(())
     }
 
     fn increase_connection_counter(&mut self) {
-        todo!()
+        let next_connection_counter = self
+            .ibc
+            .connection_counter
+            .get(*self.working_set.borrow_mut())
+            .unwrap_or_default()
+            .checked_add(1)
+            .expect("Connection counter overflow");
+
+        self.ibc
+            .connection_counter
+            .set(&next_connection_counter, *self.working_set.borrow_mut());
     }
 
     fn store_packet_commitment(
@@ -249,14 +417,22 @@ where
         commitment_path: &CommitmentPath,
         commitment: PacketCommitment,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc.packet_commitment_map.set(
+            commitment_path,
+            &commitment,
+            *self.working_set.borrow_mut(),
+        );
+        Ok(())
     }
 
     fn delete_packet_commitment(
         &mut self,
         commitment_path: &CommitmentPath,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc
+            .packet_commitment_map
+            .delete(commitment_path, *self.working_set.borrow_mut());
+        Ok(())
     }
 
     fn store_packet_receipt(
@@ -264,7 +440,10 @@ where
         receipt_path: &ReceiptPath,
         receipt: Receipt,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc
+            .packet_receipt_map
+            .set(receipt_path, &receipt, *self.working_set.borrow_mut());
+        Ok(())
     }
 
     fn store_packet_acknowledgement(
@@ -272,11 +451,17 @@ where
         ack_path: &AckPath,
         ack_commitment: AcknowledgementCommitment,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc
+            .packet_ack_map
+            .set(ack_path, &ack_commitment, *self.working_set.borrow_mut());
+        Ok(())
     }
 
     fn delete_packet_acknowledgement(&mut self, ack_path: &AckPath) -> Result<(), ContextError> {
-        todo!()
+        self.ibc
+            .packet_ack_map
+            .delete(ack_path, *self.working_set.borrow_mut());
+        Ok(())
     }
 
     fn store_channel(
@@ -284,7 +469,12 @@ where
         channel_end_path: &ChannelEndPath,
         channel_end: ChannelEnd,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc.channel_end_map.set(
+            channel_end_path,
+            &channel_end,
+            *self.working_set.borrow_mut(),
+        );
+        Ok(())
     }
 
     fn store_next_sequence_send(
@@ -292,7 +482,10 @@ where
         seq_send_path: &SeqSendPath,
         seq: Sequence,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc
+            .send_sequence_map
+            .set(seq_send_path, &seq, *self.working_set.borrow_mut());
+        Ok(())
     }
 
     fn store_next_sequence_recv(
@@ -300,7 +493,10 @@ where
         seq_recv_path: &SeqRecvPath,
         seq: Sequence,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc
+            .recv_sequence_map
+            .set(seq_recv_path, &seq, *self.working_set.borrow_mut());
+        Ok(())
     }
 
     fn store_next_sequence_ack(
@@ -308,18 +504,47 @@ where
         seq_ack_path: &SeqAckPath,
         seq: Sequence,
     ) -> Result<(), ContextError> {
-        todo!()
+        self.ibc
+            .ack_sequence_map
+            .set(seq_ack_path, &seq, *self.working_set.borrow_mut());
+        Ok(())
     }
 
     fn increase_channel_counter(&mut self) {
-        todo!()
+        let next_channel_counter = self
+            .ibc
+            .channel_counter
+            .get(*self.working_set.borrow_mut())
+            .unwrap_or_default()
+            .checked_add(1)
+            .expect("Channel counter overflow");
+
+        self.ibc
+            .channel_counter
+            .set(&next_channel_counter, *self.working_set.borrow_mut());
     }
 
     fn emit_ibc_event(&mut self, event: IbcEvent) {
-        todo!()
+        let mut events = self
+            .ibc
+            .events
+            .get(*self.working_set.borrow_mut())
+            .unwrap_or_default();
+
+        events.push(event);
+
+        self.ibc.events.set(&events, *self.working_set.borrow_mut());
     }
 
     fn log_message(&mut self, message: String) {
-        todo!()
+        let mut logs = self
+            .ibc
+            .logs
+            .get(*self.working_set.borrow_mut())
+            .unwrap_or_default();
+
+        logs.push(message);
+
+        self.ibc.logs.set(&logs, *self.working_set.borrow_mut());
     }
 }

--- a/module-system/module-implementations/sov-ibc/src/context.rs
+++ b/module-system/module-implementations/sov-ibc/src/context.rs
@@ -569,17 +569,9 @@ where
         Ok(())
     }
 
+    /// TODO: To implement this method there should be a way for IBC module to
+    /// to insert logs into the transaction receipts upon execution
     fn log_message(&mut self, message: String) -> Result<(), ContextError> {
-        let mut logs = self
-            .ibc
-            .logs
-            .get(*self.working_set.borrow_mut())
-            .unwrap_or_default();
-
-        logs.push(message);
-
-        self.ibc.logs.set(&logs, *self.working_set.borrow_mut());
-
         Ok(())
     }
 }

--- a/module-system/module-implementations/sov-ibc/src/context/clients.rs
+++ b/module-system/module-implementations/sov-ibc/src/context/clients.rs
@@ -262,7 +262,7 @@ where
         client_state_path: ClientStatePath,
         client_state: Self::AnyClientState,
     ) -> Result<(), ContextError> {
-        self.ibc.client_state_store.set(
+        self.ibc.client_state_map.set(
             &client_state_path.0,
             &client_state,
             &mut self.working_set.borrow_mut(),
@@ -276,7 +276,7 @@ where
         consensus_state_path: ClientConsensusStatePath,
         consensus_state: Self::AnyConsensusState,
     ) -> Result<(), ContextError> {
-        self.ibc.consensus_state_store.set(
+        self.ibc.consensus_state_map.set(
             &consensus_state_path,
             &consensus_state,
             &mut self.working_set.borrow_mut(),

--- a/module-system/module-implementations/sov-ibc/src/genesis.rs
+++ b/module-system/module-implementations/sov-ibc/src/genesis.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use sov_state::WorkingSet;
 
-use crate::IbcModule;
+use crate::Ibc;
 
-impl<C: sov_modules_api::Context> IbcModule<C> {
+impl<C: sov_modules_api::Context> Ibc<C> {
     pub(crate) fn init_module(
         &self,
         _config: &<Self as sov_modules_api::Module>::Config,

--- a/module-system/module-implementations/sov-ibc/src/genesis.rs
+++ b/module-system/module-implementations/sov-ibc/src/genesis.rs
@@ -7,8 +7,12 @@ impl<C: sov_modules_api::Context> Ibc<C> {
     pub(crate) fn init_module(
         &self,
         _config: &<Self as sov_modules_api::Module>::Config,
-        _working_set: &mut WorkingSet<C::Storage>,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
+        self.client_counter.set(&0, working_set);
+        self.connection_counter.set(&0, working_set);
+        self.channel_counter.set(&0, working_set);
+
         Ok(())
     }
 }

--- a/module-system/module-implementations/sov-ibc/src/lib.rs
+++ b/module-system/module-implementations/sov-ibc/src/lib.rs
@@ -89,9 +89,6 @@ pub struct Ibc<C: sov_modules_api::Context> {
 
     #[state]
     packet_ack_map: sov_state::StateMap<AckPath, AcknowledgementCommitment>,
-
-    #[state]
-    logs: sov_state::StateValue<Vec<String>>,
 }
 
 impl<C: sov_modules_api::Context> sov_modules_api::Module for Ibc<C> {

--- a/module-system/module-implementations/sov-ibc/src/lib.rs
+++ b/module-system/module-implementations/sov-ibc/src/lib.rs
@@ -10,8 +10,18 @@ mod router;
 
 use codec::ProtobufCodec;
 use context::clients::{AnyClientState, AnyConsensusState};
-use ibc::core::ics24_host::identifier::ClientId;
-use ibc::core::ics24_host::path::ClientConsensusStatePath;
+use ibc::core::events::IbcEvent;
+use ibc::core::ics03_connection::connection::ConnectionEnd;
+use ibc::core::ics04_channel::channel::ChannelEnd;
+use ibc::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
+use ibc::core::ics04_channel::packet::{Receipt, Sequence};
+use ibc::core::ics24_host::identifier::{ClientId, ConnectionId};
+use ibc::core::ics24_host::path::{
+    AckPath, ChannelEndPath, ClientConnectionPath, ClientConsensusStatePath, CommitmentPath,
+    ConnectionPath, ReceiptPath, SeqAckPath, SeqRecvPath, SeqSendPath,
+};
+use ibc::core::timestamp::Timestamp;
+use ibc::Height;
 use sov_modules_api::Error;
 use sov_modules_macros::ModuleInfo;
 use sov_state::WorkingSet;
@@ -27,11 +37,59 @@ pub struct IbcModule<C: sov_modules_api::Context> {
     pub(crate) transfer: sov_ibc_transfer::Transfer<C>,
 
     #[state]
-    pub client_state_store: sov_state::StateMap<ClientId, AnyClientState, ProtobufCodec>,
+    client_counter: sov_state::StateValue<u64>,
 
     #[state]
-    pub consensus_state_store:
+    connection_counter: sov_state::StateValue<u64>,
+
+    #[state]
+    channel_counter: sov_state::StateValue<u64>,
+
+    #[state]
+    client_update_times_map: sov_state::StateMap<(ClientId, Height), Timestamp>,
+
+    #[state]
+    client_update_heights_map: sov_state::StateMap<(ClientId, Height), Height>,
+
+    #[state]
+    client_state_map: sov_state::StateMap<ClientId, AnyClientState, ProtobufCodec>,
+
+    #[state]
+    consensus_state_map:
         sov_state::StateMap<ClientConsensusStatePath, AnyConsensusState, ProtobufCodec>,
+
+    #[state]
+    connection_end_map: sov_state::StateMap<ConnectionPath, ConnectionEnd>,
+
+    #[state]
+    connection_ids_map: sov_state::StateMap<ClientConnectionPath, Vec<ConnectionId>>,
+
+    #[state]
+    channel_end_map: sov_state::StateMap<ChannelEndPath, ChannelEnd>,
+
+    #[state]
+    send_sequence_map: sov_state::StateMap<SeqSendPath, Sequence>,
+
+    #[state]
+    recv_sequence_map: sov_state::StateMap<SeqRecvPath, Sequence>,
+
+    #[state]
+    ack_sequence_map: sov_state::StateMap<SeqAckPath, Sequence>,
+
+    #[state]
+    packet_commitment_map: sov_state::StateMap<CommitmentPath, PacketCommitment>,
+
+    #[state]
+    packet_receipt_map: sov_state::StateMap<ReceiptPath, Receipt>,
+
+    #[state]
+    packet_ack_map: sov_state::StateMap<AckPath, AcknowledgementCommitment>,
+
+    #[state]
+    events: sov_state::StateValue<Vec<IbcEvent>>,
+
+    #[state]
+    logs: sov_state::StateValue<Vec<String>>,
 }
 
 impl<C: sov_modules_api::Context> sov_modules_api::Module for IbcModule<C> {

--- a/module-system/module-implementations/sov-ibc/src/lib.rs
+++ b/module-system/module-implementations/sov-ibc/src/lib.rs
@@ -28,6 +28,12 @@ use sov_state::WorkingSet;
 
 pub struct ExampleModuleConfig {}
 
+/// the sov-ibc module that manages all IBC-related states
+///
+/// Note: this struct, named `Ibc`, as its name serves as the module name and is
+/// utilized to form prefixes for `state` fields. This naming adheres to the
+/// module naming convention used throughout the codebase, ensuring created
+/// prefixes by modules are in harmony.
 #[derive(ModuleInfo)]
 pub struct Ibc<C: sov_modules_api::Context> {
     #[address]

--- a/module-system/module-implementations/sov-ibc/src/lib.rs
+++ b/module-system/module-implementations/sov-ibc/src/lib.rs
@@ -10,7 +10,6 @@ mod router;
 
 use codec::ProtobufCodec;
 use context::clients::{AnyClientState, AnyConsensusState};
-use ibc::core::events::IbcEvent;
 use ibc::core::ics03_connection::connection::ConnectionEnd;
 use ibc::core::ics04_channel::channel::ChannelEnd;
 use ibc::core::ics04_channel::commitment::{AcknowledgementCommitment, PacketCommitment};
@@ -90,9 +89,6 @@ pub struct Ibc<C: sov_modules_api::Context> {
 
     #[state]
     packet_ack_map: sov_state::StateMap<AckPath, AcknowledgementCommitment>,
-
-    #[state]
-    events: sov_state::StateValue<Vec<IbcEvent>>,
 
     #[state]
     logs: sov_state::StateValue<Vec<String>>,

--- a/module-system/module-implementations/sov-ibc/src/lib.rs
+++ b/module-system/module-implementations/sov-ibc/src/lib.rs
@@ -29,7 +29,7 @@ use sov_state::WorkingSet;
 pub struct ExampleModuleConfig {}
 
 #[derive(ModuleInfo)]
-pub struct IbcModule<C: sov_modules_api::Context> {
+pub struct Ibc<C: sov_modules_api::Context> {
     #[address]
     pub address: C::Address,
 
@@ -92,7 +92,7 @@ pub struct IbcModule<C: sov_modules_api::Context> {
     logs: sov_state::StateValue<Vec<String>>,
 }
 
-impl<C: sov_modules_api::Context> sov_modules_api::Module for IbcModule<C> {
+impl<C: sov_modules_api::Context> sov_modules_api::Module for Ibc<C> {
     type Context = C;
 
     type Config = ExampleModuleConfig;

--- a/module-system/module-implementations/sov-ibc/src/router.rs
+++ b/module-system/module-implementations/sov-ibc/src/router.rs
@@ -7,7 +7,7 @@ use ibc::core::router::{self, ModuleId, Router};
 use sov_ibc_transfer::context::TransferContext;
 use sov_state::WorkingSet;
 
-use crate::IbcModule;
+use crate::Ibc;
 
 pub struct IbcRouter<'ws, 'c, C: sov_modules_api::Context> {
     pub transfer_ctx: TransferContext<'ws, 'c, C>,
@@ -18,7 +18,7 @@ where
     C: sov_modules_api::Context,
 {
     pub fn new(
-        ibc_mod: &'t IbcModule<C>,
+        ibc_mod: &'t Ibc<C>,
         sdk_context: &'c C,
         working_set: Rc<RefCell<&'ws mut WorkingSet<C::Storage>>>,
     ) -> IbcRouter<'ws, 'c, C> {


### PR DESCRIPTION
### Remarks:

- Related to the implementation of `commitment_prefix` method: as the entire module prefix consists of the module's name [derived from its struct name](https://github.com/informalsystems/sovereign-sdk/blob/d149286ae7e6820a845f594b827fbf2fb16eaa92/module-system/sov-modules-macros/src/module_info.rs#L134) (and for consistency with other module names as well) the `IbcModule` struct renamed to `Ibc`.

- Methods like `host_height` need info from the host, left unimplemented to work on in a separate PR.