### PR TITLE
Fix mock validity cond; improve guest logging

### DIFF
--- a/full-node/sov-stf-runner/src/runner.rs
+++ b/full-node/sov-stf-runner/src/runner.rs
@@ -196,16 +196,16 @@ where
                         state_transition_witness: slot_result.witness,
                     };
                 vm.add_hint(transition_data);
-
-                match config {
-                    ProofGenConfig::Simulate(verifier) => {
-                        verifier.run_block(vm.simulate_with_hints()).map_err(|e| {
+                tracing::info_span!("guest_execution").in_scope(|| match config {
+                    ProofGenConfig::Simulate(verifier) => verifier
+                        .run_block(vm.simulate_with_hints())
+                        .map_err(|e| {
                             anyhow::anyhow!("Guest execution must succeed but failed with {:?}", e)
-                        })?;
-                    }
-                    ProofGenConfig::Execute => vm.run(false)?,
-                    ProofGenConfig::Prover => vm.run(true)?,
-                }
+                        })
+                        .map(|_| ()),
+                    ProofGenConfig::Execute => vm.run(false),
+                    ProofGenConfig::Prover => vm.run(true),
+                })?;
             }
             let next_state_root = slot_result.state_root;
 

--- a/rollup-interface/src/state_machine/mocks/da.rs
+++ b/rollup-interface/src/state_machine/mocks/da.rs
@@ -373,7 +373,7 @@ impl DaVerifier for MockDaVerifier {
         _inclusion_proof: <Self::Spec as DaSpec>::InclusionMultiProof,
         _completeness_proof: <Self::Spec as DaSpec>::CompletenessProof,
     ) -> Result<<Self::Spec as DaSpec>::ValidityCondition, Self::Error> {
-        Ok(MockValidityCond { is_valid: true })
+        Ok(Default::default())
     }
 }
 

--- a/rollup-interface/src/state_machine/mocks/validity_condition.rs
+++ b/rollup-interface/src/state_machine/mocks/validity_condition.rs
@@ -9,20 +9,18 @@ use crate::zk::{ValidityCondition, ValidityConditionChecker};
 
 /// A trivial test validity condition structure that only contains a boolean
 #[derive(
-    Debug,
-    BorshDeserialize,
-    BorshSerialize,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Clone,
-    Copy,
-    Default,
-    Eq,
+    Debug, BorshDeserialize, BorshSerialize, Serialize, Deserialize, PartialEq, Clone, Copy, Eq,
 )]
 pub struct MockValidityCond {
     /// The associated validity condition field. If it is true, the validity condition is verified
     pub is_valid: bool,
+}
+
+// Validity conditions should usually be valid
+impl Default for MockValidityCond {
+    fn default() -> Self {
+        Self { is_valid: true }
+    }
 }
 
 impl ValidityCondition for MockValidityCond {


### PR DESCRIPTION
# Description
This PR fixes a bug in the Mock DA service which caused CI to fail [here](https://github.com/Sovereign-Labs/sovereign-sdk/pull/974). 

Previously, the Mock DA service generated validity conditions using a derived `Default` impl, which set the boolean `is_valid` to false. This PR sets the default to `true`, meaning that the rollup won't reject blocks by default. It also makes a minor change to logging which I found useful in debugging the issue.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
